### PR TITLE
Remove workaround for requests < 2.0 on python 3

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -256,10 +256,6 @@ class RequestsTransport(Transport):
         # xmlrpclib fails to escape \r
         request_body = request_body.replace(b'\r', b'&#xd;')
 
-        # Needed for python-requests < 2.0 with python3, otherwise we get
-        # Content-Type error later for the POST request
-        request_body = request_body.decode('utf-8')
-
         return self._request_helper(url, request_body)
 
 


### PR DESCRIPTION
- this workaround caused systems with ndg-httpsclient installed to
  error out when requests is used
- requests versions 0.14.2 to 1.2.3 do not work due to unrelated issues
  and hence no point carrying this workaround
```sh
[abn@zoidberg temp]$ pip list
pip (6.0.8)
python-bugzilla (1.2.1)
requests (1.0.0)
setuptools (12.0.5)
[abn@zoidberg temp]$ ./temp/bin/bugzilla login foo foo
__init__() got an unexpected keyword argument 'strict'


[abn@zoidberg temp]$ pip list
pip (6.0.8)
python-bugzilla (1.2.1)
requests (1.2.3)
setuptools (12.0.5)
[abn@zoidberg temp]$ ./temp/bin/bugzilla login foo foo
__init__() got an unexpected keyword argument 'strict'
```
- requests version 0.14.1 and earlier works without this workaround
```sh
[abn@zoidberg temp]$ pip list
pip (6.0.8)
python-bugzilla (1.2.1)
requests (0.14.1)
setuptools (12.0.5)
[abn@zoidberg temp]$ ./temp/bin/bugzilla login foo foo
[14:39:18] INFO (bugzilla:1160) Connecting to https://bugzilla.redhat.com/xmlrpc.cgi
[14:39:18] INFO (bugzilla:1163) Autodetecting Bugzilla type
[14:39:18] INFO (__init__:46) Using RHBugzilla for URL containing bugzilla.redhat.com
[14:39:18] INFO (__init__:114) Chose subclass RHBugzilla v0.1
[14:39:18] INFO (base:672) Using username/password for authentication
[14:39:18] INFO (base:680) Logging in... 
Login failed: The username or password you entered is not valid.
```